### PR TITLE
Fix unstability with the helm chart in argocd

### DIFF
--- a/charts/banana-split/templates/_helpers.tpl
+++ b/charts/banana-split/templates/_helpers.tpl
@@ -71,3 +71,10 @@ Env for app
       name: {{ include "banana-split.fullname" . }}-db-app
       key: uri
 {{- end }}
+
+{{/*
+Image tag used in the app
+*/}}
+{{- define "banana-split.tag" -}}
+{{ .Values.image.tag | default (printf "%s%s" "v" .Chart.AppVersion) }}
+{{- end }}

--- a/charts/banana-split/templates/deployment.yaml
+++ b/charts/banana-split/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s%s" "v" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ include "banana-split.tag" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/banana-split/templates/migrations.yaml
+++ b/charts/banana-split/templates/migrations.yaml
@@ -2,15 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ include "banana-split.fullname" . }}-migration-start-{{ randNumeric 6 }}"
+  name: "{{ include "banana-split.fullname" . }}-migration-start-{{ include "banana-split.tag" . | sha1sum | substr 0 8 }}"
   labels:
     {{- include "banana-split.labels" . | nindent 4 }}
     role: migration-start
-  # annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    # helm.sh/hook: pre-upgrade,pre-install
-    # helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
 spec:
   template:
     metadata:
@@ -26,7 +23,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s%s" "v" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ include "banana-split.tag" . }}"
           command:
             - sh
             - -c
@@ -60,8 +57,6 @@ metadata:
     {{- include "banana-split.labels" . | nindent 4 }}
     role: migration-complete
   annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
     helm.sh/hook: post-upgrade,post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
@@ -79,14 +74,14 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "%s%s" "v" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ include "banana-split.tag" . }}"
           command:
             - sh
             - -c
             - |
               set -euo pipefail
               set -x
-              if ! [[ $(timeout 10 banana-split migrations status | grep status | sed 's/^ *"status": "\(.*\)"/\1/') = "Complete" ]]; then
+              if ! [[ "$(timeout 10 banana-split migrations status | grep status | sed 's/^ *"status": "\(.*\)"/\1/')" = "Complete" ]]; then
                 banana-split migrations complete
               fi
 


### PR DESCRIPTION
The chart was using randNumeric to ensure that the start migrations job is created always, but now instead of using that we replace that with hashing the tag of the image so that should be enough for now.